### PR TITLE
fix: configure eslint import resolver for TypeScript projects

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,20 +6,23 @@ import mochaRules from "@ethberry/eslint-config/tests/mocha.mjs";
 
 export default [
   {
-    ignores: [
-      "**/dist",
-    ]
+    ignores: ["**/dist"],
   },
 
   {
     languageOptions: {
       parserOptions: {
-        project: [
-          "./tsconfig.eslint.json",
-        ],
-        tsconfigRootDir: import.meta.dirname
+        project: ["./tsconfig.eslint.json"],
+        tsconfigRootDir: import.meta.dirname,
       },
-    }
+    },
+    settings: {
+      "import/resolver": {
+        typescript: {
+          project: ["./tsconfig.eslint.json"],
+        },
+      },
+    },
   },
 
   ...typescriptRules,


### PR DESCRIPTION
## Summary
- Add `settings.import/resolver.typescript.project` matching `parserOptions.project`
- Remove workarounds for `import/no-unresolved` (eslint-disable comments and rule overrides)

## Test plan
- [x] ESLint resolves TypeScript imports without `import/no-unresolved` false positives
- [ ] CI lint/build passes

Made with [Cursor](https://cursor.com)